### PR TITLE
docs: improve setup instructions for fish, brew, and node tools

### DIFF
--- a/src/content/docs/setup/fish-shell.md
+++ b/src/content/docs/setup/fish-shell.md
@@ -2,7 +2,7 @@
 title: 'Fish shell'
 sidebar:
   order: 2
-lastUpdated: 2025-06-10
+lastUpdated: 2025-06-11
 ---
 
 [Fish](https://fishshell.com/) is the superior shell with sensible defaults.
@@ -50,6 +50,12 @@ Wrap `brew` with `Homebrew-file` in your `config.fish` file.
 if test -f (brew --prefix)/etc/brew-wrap.fish
   source (brew --prefix)/etc/brew-wrap.fish
 end
+```
+
+[Set your theme](https://fishshell.com/docs/current/tutorial.html#syntax-highlighting):
+
+```sh
+fish_config
 ```
 
 ## Starship

--- a/src/content/docs/setup/macos-package-manager.md
+++ b/src/content/docs/setup/macos-package-manager.md
@@ -2,6 +2,7 @@
 title: 'Package manager for macOS'
 sidebar:
   order: 1
+lastUpdated: 2025-06-11
 ---
 
 ## Brew
@@ -40,18 +41,18 @@ brew leaves
 
 ## Brewfile
 
-Easily re-install all of the packages you've installed with `brew` on another machine using [Homebrew-file](https://homebrew-file.readthedocs.io/en/latest/index.html).
+Easily re-install all of the packages you've installed with `brew` on another machine using a [Brewfile](https://docs.brew.sh/Brew-Bundle-and-Brewfile).
 
-### Installation
+Export your installed dependencies to a `Brewfile` in the current directory
 
 ```sh
-brew install rcmdnk/file/brew-file
+brew bundle dump
 ```
 
-With an existing `Brewfile`, copy that file to `~/.config/brewfile/Brewfile` and run the following command. You may need to wrap the `brew` command as shown in the [fish installation](/setup/fish-shell).
+Install your dependencies using an existing `Brewfile`
 
 ```sh
-brew file install
+brew bundle install
 ```
 
 ## Devbox

--- a/src/content/docs/setup/managing-node-version.md
+++ b/src/content/docs/setup/managing-node-version.md
@@ -1,6 +1,6 @@
 ---
 title: 'Managing node and package manager versions'
-lastUpdated: 2025-06-10
+lastUpdated: 2025-06-11
 ---
 
 ## mise
@@ -40,6 +40,12 @@ You don't need to add `mise` to the `PATH` because it adds itself to the `PATH`.
 ```sh
 mise missing: node@18.20.4
 $ mise install
+```
+
+You can install `npm` tools and have `mise` manage them across all of your `node` versions:
+
+```sh
+mise use -g npm:prettier
 ```
 
 ## Alternatives


### PR DESCRIPTION
Add fish shell theme setup using `fish_config` for easier customization.
Clarify Brewfile usage by updating commands to `brew bundle dump` and
`brew bundle install` for exporting and installing packages. Enhance node
version management docs by showing how to install npm tools globally with
`mise use -g npm:prettier`. These changes improve clarity and usability of
setup guides.