### PR TITLE
docs(setup): add info on overwriting Brewfile with brew bundle

### DIFF
--- a/src/content/docs/setup/macos-package-manager.md
+++ b/src/content/docs/setup/macos-package-manager.md
@@ -55,6 +55,12 @@ Install your dependencies using an existing `Brewfile`
 brew bundle install
 ```
 
+You can overwrite an existing `Brewfile` by running the following command. This is useful when you already version your `Brewfile` using `git`.
+
+```sh
+brew bundle dump --force
+```
+
 ## Devbox
 
 ### Installation


### PR DESCRIPTION
Add instructions for using `brew bundle dump --force` to overwrite an
existing Brewfile. This helps users who version their Brewfile with git
to update it easily without manual deletion.