### PR TITLE
docs: add instructions to list installed Homebrew casks

### DIFF
--- a/src/content/docs/setup/macos-package-manager.md
+++ b/src/content/docs/setup/macos-package-manager.md
@@ -39,6 +39,12 @@ Show what you have installed at a top level and excludes their dependencies.
 brew leaves
 ```
 
+You can also view your installed casks
+
+```sh
+brew list --cask
+```
+
 ## Brewfile
 
 Easily re-install all of the packages you've installed with `brew` on another machine using a [Brewfile](https://docs.brew.sh/Brew-Bundle-and-Brewfile).


### PR DESCRIPTION
Add a section showing how to view installed casks using `brew list --cask`.
This complements the existing instructions for listing installed formulae and
helps users manage their Homebrew packages more effectively on macOS.