### PR TITLE
docs: update git config example to use global ignore file path

### DIFF
--- a/src/content/docs/setup/git.md
+++ b/src/content/docs/setup/git.md
@@ -9,7 +9,6 @@ Sensible `git` options to set.
 
 ```sh
 git config --global push.autosetupremote true
-git config --global core.excludeFiles ~/.gitignore
 git config --global blame.ignoreRevsFile .git-blame-ignore-revs
 git config --global pull.rebase true
 git config --global push.useForceIfIncludes true
@@ -36,16 +35,14 @@ Your `.gitconfig` should look something like:
 [push]
         autosetupremote = true
         useForceIfIncludes = true
-[core]
-        excludeFiles = /Users/john.smith/.gitignore
 [pull]
         rebase = true
 ```
 
-It can also be useful to add the following to your global `.gitignore`:
+It can also be useful to add the following to your global `.gitignore` (located by default in `~/.config/git/ignore`):
 
 ```
-// ~/.gitignore
+// ~/.config/git/ignore
 
 .idea
 .DS_Store


### PR DESCRIPTION
Remove deprecated core.excludeFiles setting and update the example to
reference the default global gitignore location at ~/.config/git/ignore.
This clarifies the recommended configuration and aligns with current git
best practices.